### PR TITLE
遍历网卡获取IP时，优先获取本地站点IP或第一个可用IP

### DIFF
--- a/xxl-rpc-core/src/main/java/com/xxl/rpc/util/IpUtil.java
+++ b/xxl-rpc-core/src/main/java/com/xxl/rpc/util/IpUtil.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.util.Enumeration;
 import java.util.regex.Pattern;
 
@@ -39,53 +40,40 @@ public class IpUtil {
     }
 
     /**
-     * get first valid addredd
+     * get first valid address
      *
      * @return InetAddress
      */
     private static InetAddress getFirstValidAddress() {
-
         // NetworkInterface address
+        Enumeration<NetworkInterface> interfaces;
         try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            if (interfaces != null) {
-                while (interfaces.hasMoreElements()) {
-                    try {
-                        NetworkInterface network = interfaces.nextElement();
-                        Enumeration<InetAddress> addresses = network.getInetAddresses();
-                        if (addresses != null) {
-                            while (addresses.hasMoreElements()) {
-                                try {
-                                    InetAddress address = addresses.nextElement();
-                                    if (isValidAddress(address)) {
-                                        return address;
-                                    }
-                                } catch (Throwable e) {
-                                    logger.error("Failed to retriving ip address, " + e.getMessage(), e);
-                                }
-                            }
-                        }
-                    } catch (Throwable e) {
-                        logger.error("Failed to retriving ip address, " + e.getMessage(), e);
+            interfaces = NetworkInterface.getNetworkInterfaces();
+        } catch (SocketException e) {
+            logger.error("Failed to retriving ip address, " + e.getMessage(), e);
+            return null;
+        }
+
+        InetAddress candidateAddress = null;
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface network = interfaces.nextElement();
+            Enumeration<InetAddress> addresses = network.getInetAddresses();
+            while (addresses.hasMoreElements()) {
+                InetAddress address = addresses.nextElement();
+                if (isValidAddress(address)) {
+                    // return site-local address immediately.
+                    if (address.isSiteLocalAddress()) {
+                        return address;
+                    }
+                    // get first candidate address.
+                    if (candidateAddress == null) {
+                        candidateAddress = address;
                     }
                 }
             }
-        } catch (Throwable e) {
-            logger.error("Failed to retriving ip address, " + e.getMessage(), e);
         }
-
-        // getLocalHost address
-        try {
-            InetAddress localAddress = InetAddress.getLocalHost();
-            if (isValidAddress(localAddress)) {
-                return localAddress;
-            }
-        } catch (Throwable e) {
-            logger.error("Failed to retriving ip address, " + e.getMessage(), e);
-        }
-
         logger.error("Could not get local host ip address, will use 127.0.0.1 instead.");
-        return null;
+        return candidateAddress;
     }
 
 
@@ -99,7 +87,7 @@ public class IpUtil {
             return LOCAL_ADDRESS;
         }
         InetAddress localAddress = getFirstValidAddress();
-        LOCAL_ADDRESS = localAddress.getHostAddress();
+        LOCAL_ADDRESS = localAddress != null ? localAddress.getHostAddress() : null;
         return LOCAL_ADDRESS;
     }
 


### PR DESCRIPTION
前一次的逻辑是：getLocalHost()先获取本地站点IP，其次遍历网卡和IP优先获取第一个合法的IP；
目前的逻辑是：遍历网卡和IP优先获取第一个合法的IP，其次getLocalHost()获取本地站点IP；

我的修改：直接在遍历网卡和IP中，优先获取isSiteLocalAddress()本地站点IP，其次再是第一个合法的IP。
以及修改getAddress()方法中可能会导致NPE问题。

这次修改的原因是，在kubernetes和docker环境中运行时，调用InetAddress.getLocalHost()方法会报以下错误：

```
2018-10-19 10:12:16.901 [Thread-5] [ERROR] IpUtil - Failed to retriving ip address, dockerd: dockerd: Name or service not known
java.net.UnknownHostException: dockerd: dockerd: Name or service not known
at java.net.InetAddress.getLocalHost(InetAddress.java:1505)
at com.xxl.job.core.util.IpUtil.getFirstValidAddress(IpUtil.java:47)
at com.xxl.job.core.util.IpUtil.getAddress(IpUtil.java:92)
at com.xxl.job.core.util.IpUtil.getIp(IpUtil.java:102)
at com.xxl.job.core.util.IpUtil.getIpPort(IpUtil.java:115)
at com.xxl.job.core.thread.ExecutorRegistryThread.start(ExecutorRegistryThread.java:44)
at com.xxl.job.core.rpc.netcom.jetty.server.JettyServer$1.run(JettyServer.java:50)
at java.lang.Thread.run(Thread.java:748)
Caused by: java.net.UnknownHostException: dockerd: Name or service not known
at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:928)
at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1323)
at java.net.InetAddress.getLocalHost(InetAddress.java:1500)
... 7 common frames omitted
```

kubernetes有自己的dns，所以localhost就不一定能获取得到了；而且，在遍历网卡中也包含本地站点IP，因此直接在遍历网卡中获取，就不再一次调用InetAddress.getLocalHost()获取了。
