### PR TITLE
服务注册中心，当某节点下线时，discoveryData无法去除已下线节点

### DIFF
--- a/xxl-rpc-core/src/main/java/com/xxl/rpc/registry/impl/ZkServiceRegistry.java
+++ b/xxl-rpc-core/src/main/java/com/xxl/rpc/registry/impl/ZkServiceRegistry.java
@@ -210,6 +210,7 @@ public class ZkServiceRegistry extends ServiceRegistry {
                 }
 
                 if (childPathData.size() > 0) {
+                	existValues.clear();
                     existValues.addAll(childPathData.keySet());
                 }
             }


### PR DESCRIPTION

服务注册中心，当某节点下线时，discoveryData无法去除已下线节点

existValues.addAll(childPathData.keySet())前先clear该set数据