### PR TITLE
Bug 解决调度器升级spring boot 2.0+后导致执行器注册时调用 NettyHttpConnectClient 超时 实际执行…

### DIFF
--- a/xxl-rpc-core/src/main/java/com/xxl/rpc/remoting/net/impl/netty_http/client/NettyHttpConnectClient.java
+++ b/xxl-rpc-core/src/main/java/com/xxl/rpc/remoting/net/impl/netty_http/client/NettyHttpConnectClient.java
@@ -100,9 +100,9 @@ public class NettyHttpConnectClient extends ConnectClient {
     public void send(XxlRpcRequest xxlRpcRequest) throws Exception {
         byte[] requestBytes = serializer.serialize(xxlRpcRequest);
 
-        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, new URI(address).toASCIIString(), Unpooled.wrappedBuffer(requestBytes));
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, new URI(address).getRawPath(), Unpooled.wrappedBuffer(requestBytes));
         request.headers().set(HttpHeaderNames.HOST, host);
-        request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderNames.CONNECTION);
+        request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
         request.headers().set(HttpHeaderNames.CONTENT_LENGTH, request.content().readableBytes());
 
         this.channel.writeAndFlush(request).sync();


### PR DESCRIPTION
…返回状态为400