### PR TITLE
处理netty连接时，没有正常处理异常问题

### DIFF
--- a/xxl-rpc-core/src/main/java/com/xxl/rpc/remoting/net/impl/netty_http/client/NettyHttpConnectClient.java
+++ b/xxl-rpc-core/src/main/java/com/xxl/rpc/remoting/net/impl/netty_http/client/NettyHttpConnectClient.java
@@ -65,15 +65,19 @@ public class NettyHttpConnectClient extends ConnectClient {
                     }
                 })
                 .option(ChannelOption.SO_KEEPALIVE, true);
-        this.channel = bootstrap.connect(host, port).sync().channel();
-
-        this.serializer = serializer;
+        try{
+            this.channel = bootstrap.connect(host, port).sync().channel();
+        }catch (Exception e){
+            logger.error(">>>>>>>>>>> xxl-rpc netty client caught exception: ",e.getCause());
+        }
 
         // valid
         if (!isValidate()) {
             close();
             return;
         }
+
+        this.serializer = serializer;
 
         logger.debug(">>>>>>>>>>> xxl-rpc netty client proxy, connect to server success at host:{}, port:{}", host, port);
     }


### PR DESCRIPTION
处理netty连接时，没有正常处理异常问题，导致服务线程没有正常关闭。例如像xxl-job调用这个rpc时，会去循环调用netty client连接 xxl-job-admin，如果xxl-job-admin服务未开启。那么每过30s就会起一个netty client线程，直到项目 oom