### PR TITLE
Update NettyConnectClient.java

### DIFF
--- a/xxl-rpc-core/src/main/java/com/xxl/rpc/core/remoting/net/impl/netty/client/NettyConnectClient.java
+++ b/xxl-rpc-core/src/main/java/com/xxl/rpc/core/remoting/net/impl/netty/client/NettyConnectClient.java
@@ -42,7 +42,7 @@ public class NettyConnectClient extends ConnectClient {
 
         // group
         if (nioEventLoopGroup == null) {
-            synchronized (NettyHttpConnectClient.class) {
+            synchronized (NettyConnectClient.class) {
                 if (nioEventLoopGroup == null) {
                     nioEventLoopGroup = new NioEventLoopGroup();
                     xxlRpcInvokerFactory.addStopCallBack(new BaseCallback() {


### PR DESCRIPTION
修正了init方法初始化NioEventLoopGroup对象在同步代码块中加的类锁对象
是NettyConnectClient.class而不是NettyHttpConnectClient.class