### PR TITLE
Always send response

### DIFF
--- a/xxl-rpc-core/src/main/java/com/xxl/rpc/core/remoting/net/impl/netty_http/server/NettyHttpServerHandler.java
+++ b/xxl-rpc-core/src/main/java/com/xxl/rpc/core/remoting/net/impl/netty_http/server/NettyHttpServerHandler.java
@@ -84,6 +84,7 @@ public class NettyHttpServerHandler extends SimpleChannelInboundHandler<FullHttp
                 // filter beat
                 if (Beat.BEAT_ID.equalsIgnoreCase(xxlRpcRequest.getRequestId())){
                     logger.debug(">>>>>>>>>>> xxl-rpc provider netty_http server read beat-ping.");
+                    writeResponse(ctx, keepAlive, new byte[0]);
                     return;
                 }
 


### PR DESCRIPTION
Hi!

Over in the OpenTelemetry Java Instrumentation project, we got a report about our project causing OOM when instrumenting xxl-rpc's netty usage (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11942).

We have mitigated the OOM (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12003), but we aren't able to correctly instrument netty when there's no response sent for a request (because we can't tell the difference between that and HTTP pipelining).

Is there any chance you'd accept this PR to send an empty response here, so that we can correctly instrument xxl-rpc? Thanks!