### PR TITLE
Fix the type conversion issue 

### DIFF
--- a/xxl-rpc-core/src/main/java/com/xxl/rpc/core/serializer/impl/JsonSerializer.java
+++ b/xxl-rpc-core/src/main/java/com/xxl/rpc/core/serializer/impl/JsonSerializer.java
@@ -28,7 +28,7 @@ public class JsonSerializer extends Serializer {
     @Override
     public void allowPackageList(List<String> packageList) {
         if (packageList!=null && !packageList.isEmpty()) {
-            autoTypeBeforeHandler = JSONReader.autoTypeFilter((String[]) packageList.toArray());
+            autoTypeBeforeHandler = JSONReader.autoTypeFilter(packageList.toArray(new String[0]));
         }
     }
 

--- a/xxl-rpc-core/src/main/java/com/xxl/rpc/core/serializer/impl/JsonbSerializer.java
+++ b/xxl-rpc-core/src/main/java/com/xxl/rpc/core/serializer/impl/JsonbSerializer.java
@@ -26,7 +26,7 @@ public class JsonbSerializer extends Serializer {
     @Override
     public void allowPackageList(List<String> packageList) {
         if (packageList!=null && !packageList.isEmpty()) {
-            autoTypeBeforeHandler = JSONReader.autoTypeFilter((String[]) packageList.toArray());
+            autoTypeBeforeHandler = JSONReader.autoTypeFilter(packageList.toArray(new String[0]));
         }
     }
 


### PR DESCRIPTION
Fix the type conversion issue  of `packageList.toArray()` in `JsonSerializer.java` and `JsonbSerializer.java` by replacing it with `packageList.toArray(new String[0])` to avoid potential `ClassCastException`.